### PR TITLE
Output shader: single triangle quad

### DIFF
--- a/main.js
+++ b/main.js
@@ -293,7 +293,7 @@ const renderLoop = () => {
   });
   pass.setPipeline(renderOutputPipeline);
   pass.setBindGroup(0, renderOutputBindGroup[step%2]);
-  pass.draw(6, 1);
+  pass.draw(3, 1);
   pass.end();
 
   // Update uniforms buffer

--- a/output.js
+++ b/output.js
@@ -12,21 +12,15 @@ struct VertexOutput {
 @vertex
 fn vert_main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
   var pos = array(
-    vec2( 1.0,  1.0),
-    vec2( 1.0, -1.0),
+    vec2(-1.0,  3.0),
     vec2(-1.0, -1.0),
-    vec2( 1.0,  1.0),
-    vec2(-1.0, -1.0),
-    vec2(-1.0,  1.0),
+    vec2( 3.0, -1.0),
   );
 
   var uv = array(
-    vec2(1.0, 1.0),
-    vec2(1.0, 0.0),
+    vec2(0.0, 2.0),
     vec2(0.0, 0.0),
-    vec2(1.0, 1.0),
-    vec2(0.0, 0.0),
-    vec2(0.0, 1.0),
+    vec2(2.0, 0.0),
   );
 
   var output : VertexOutput;


### PR DESCRIPTION
Hi, and thanks for sharing the code for the path tracer on WebGPU!

Here's a small optimization trick to draw the output with a single triangle instead of two.

More details:

- https://webgpufundamentals.org/webgpu/lessons/webgpu-large-triangle-to-cover-clip-space.html
- https://www.reddit.com/r/gamedev/comments/2j17wk/a_slightly_faster_bufferless_vertex_shader_trick/
- https://luruke.medium.com/simple-postprocessing-in-three-js-91936ecadfb7